### PR TITLE
Drop roda container dependency

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -2,6 +2,10 @@ source 'https://rubygems.org'
 
 gemspec
 
+group :test do
+  gem 'roda-container'
+end
+
 group :tools do
   gem 'rubocop'
   gem 'guard'

--- a/README.md
+++ b/README.md
@@ -1,6 +1,20 @@
 # roda-flow
 
+Resolve objects from an IoC container within the flow of your Roda routes.
+
+## Requirements
+
+Your Roda application class must respond to the `#resolve(container_key)` method and return the object matching the container key.
+
+You can implement this method yourself, with your own container, or you can use the [roda-container](https://github.com/AMHOL/roda-container) plugin to turn your Roda app into a [dry-container](https://github.com/AMHOL/roda-container) and offer the `#resolve` method for you.
+
+## Example
+
+This example uses the roda-container plugin.
+
 ```ruby
+require "roda/plugins/container"
+
 User = Struct.new(:id, :name, :email)
 
 class Repository
@@ -100,6 +114,7 @@ end
 class App < Roda
   plugin :all_verbs
   plugin :json
+  plugin :container
   plugin :flow
 
   route do |r|

--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@ Resolve objects from an IoC container within the flow of your Roda routes.
 
 Your Roda application class must respond to the `#resolve(container_key)` method and return the object matching the container key.
 
-You can implement this method yourself, with your own container, or you can use the [roda-container](https://github.com/AMHOL/roda-container) plugin to turn your Roda app into a [dry-container](https://github.com/AMHOL/roda-container) and offer the `#resolve` method for you.
+You can implement this method yourself, with your own container, or you can use the [roda-container](https://github.com/AMHOL/roda-container) plugin to turn your Roda app into a [dry-container](https://github.com/dry-rb/dry-container) and offer the `#resolve` method for you.
 
 ## Example
 

--- a/lib/roda/plugins/flow.rb
+++ b/lib/roda/plugins/flow.rb
@@ -1,10 +1,6 @@
 class Roda
   module RodaPlugins
     module Flow
-      def self.load_dependencies(app, _opts = nil)
-        app.plugin :container
-      end
-
       module RequestMethods
         def resolve(*args, &block)
           on(resolve: args, &block)

--- a/roda-flow.gemspec
+++ b/roda-flow.gemspec
@@ -13,9 +13,6 @@ Gem::Specification.new do |spec|
   spec.files        = Dir['README.md', 'LICENSE.txt', 'lib/**/*']
   spec.require_path = 'lib'
 
-  spec.add_runtime_dependency 'dry-container', '~> 0.2.4'
-  spec.add_runtime_dependency 'roda-container'
-
   spec.add_development_dependency 'bundler'
   spec.add_development_dependency 'roda'
   spec.add_development_dependency 'rake', '~> 10.3'

--- a/spec/integration/roda/plugins/flow/object_controller_flow_spec.rb
+++ b/spec/integration/roda/plugins/flow/object_controller_flow_spec.rb
@@ -101,6 +101,7 @@ RSpec.describe 'flow plugin' do
       class App < Roda
         plugin :all_verbs
         plugin :json
+        plugin :container
         plugin :flow
 
         route do |r|

--- a/spec/integration/roda/plugins/flow/proc_controller_flow_spec.rb
+++ b/spec/integration/roda/plugins/flow/proc_controller_flow_spec.rb
@@ -37,6 +37,7 @@ RSpec.describe 'flow plugin' do
       class App < Roda
         plugin :all_verbs
         plugin :json
+        plugin :container
         plugin :flow
 
         route do |r|


### PR DESCRIPTION
Make it possible for roda-flow to work with any roda app that implements the `#resolve` method by dropping the hard-coded dependency on the roda-container plugin. This means we can use it from with dry-web-roda instead of vendoring a slightly modified copy of this plugin.

I've updated the docs to make it clear that you can still get a nice standalone OOTB experience with roda-flow simply by combining it with the roda-container plugin yourself.

Think this is OK, @AMHOL?

/cc @solnic
