### PR TITLE
Added a provision to use defaults

### DIFF
--- a/spec/integration/roda/plugins/flow/object_controller_flow_with_defaults_spec.rb
+++ b/spec/integration/roda/plugins/flow/object_controller_flow_with_defaults_spec.rb
@@ -1,0 +1,190 @@
+require 'spec_helper'
+require 'support/test_repository'
+require 'support/users_controller'
+
+RSpec.describe 'flow plugin with defaults' do
+  before do
+    module Test
+      class App < Roda
+        plugin :all_verbs
+        plugin :json
+        plugin :container
+        plugin :flow
+
+        route do |r|
+          r.on 'defaults' do
+            r.on 'users' do
+              r.resolve('repositories.user') do |user_repo|
+                flow_defaults(inject: [r.response, user_repo], call_with: [r.params]) do
+                  r.is do
+                    r.get to: 'controllers.users#index',
+                      call_with: false
+
+                    r.post to: 'controllers.users#create'
+                  end
+
+                  r.on :user_id do |user_id|
+                    flow_defaults(call_with: [user_id]) do
+                      r.get to: 'controllers.users#show'
+
+                      r.put to: 'controllers.users#update',
+                        call_with: [user_id, r.params]
+
+                      r.delete to: 'controllers.users#destroy'
+                    end
+                  end
+                end
+              end
+            end
+          end
+        end
+
+        register('repositories.user', ::TestRepository.new)
+        register('controllers.users') { |*args| ::UsersController.new(*args) }
+      end
+    end
+  end
+
+
+  describe '#index' do
+    let(:users) do
+      [
+        { id: 1, name: 'John', email: 'john@gotmail.com' },
+        { id: 2, name: 'Jill', email: 'jill@gotmail.com' }
+      ]
+    end
+
+    before do
+      repo = Test::App.resolve('repositories.user')
+      users.each do |user_attributes|
+        repo.push(::User.new(*user_attributes.values))
+      end
+    end
+
+    it 'returns a 200 with users array representation', focus: true do
+      get '/defaults/users', {}
+
+      expect(last_response.status).to eq(200)
+      expect(last_response.body).to eq(users.to_json)
+    end
+  end
+
+  describe '#show' do
+    let(:user) do
+      { id: 1, name: 'John', email: 'john@gotmail.com' }
+    end
+
+    before do
+      Test::App.resolve('repositories.user').push(::User.new(*user.values))
+    end
+
+    context 'with invalid user_id' do
+      it 'returns a 404 with an empty hash representation' do
+        get '/defaults/users/2', {}
+
+        expect(last_response.status).to eq(404)
+        expect(last_response.body).to eq({}.to_json)
+      end
+    end
+
+    context 'with valid user_id' do
+      it 'returns a 200 with the user representation' do
+        get '/defaults/users/1', {}
+
+        expect(last_response.status).to eq(200)
+        expect(last_response.body).to eq(user.to_json)
+      end
+    end
+  end
+
+  describe '#create' do
+    context 'with invalid params' do
+      it 'returns a 422 with an invalid user representation' do
+        post '/defaults/users', name: '', email: 'john@gotmail.com'
+
+        expect(last_response.status).to eq(422)
+        expect(last_response.body).to eq({
+          id: nil,
+          name: '',
+          email: 'john@gotmail.com'
+        }.to_json)
+      end
+    end
+
+    context 'with valid params' do
+      it 'returns a 201 with the user representation' do
+        post '/defaults/users', name: 'John', email: 'john@gotmail.com'
+
+        expect(last_response.status).to eq(201)
+        expect(last_response.body).to eq({ id: 1, name: 'John', email: 'john@gotmail.com' }.to_json)
+      end
+    end
+  end
+
+  describe '#update' do
+    let(:user) do
+      { id: 1, name: 'John', email: 'john@gotmail.com' }
+    end
+
+    before do
+      Test::App.resolve('repositories.user').push(::User.new(*user.values))
+    end
+
+    context 'with invalid user_id' do
+      it 'returns a 404 with an empty hash representation' do
+        put '/defaults/users/2', name: 'John Smith'
+
+        expect(last_response.status).to eq(404)
+        expect(last_response.body).to eq({}.to_json)
+      end
+    end
+
+    context 'with valid user_id' do
+      context 'with invalid params' do
+        it 'returns a 422 with the invalid user representation' do
+          put '/defaults/users/1', name: ''
+
+          expect(last_response.status).to eq(422)
+          expect(last_response.body).to eq(user.update(name: '').to_json)
+        end
+      end
+
+      context 'with valid params' do
+        it 'returns a 200 with the user representation' do
+          put '/defaults/users/1', name: 'John Smith'
+
+          expect(last_response.status).to eq(200)
+          expect(last_response.body).to eq(user.update(name: 'John Smith').to_json)
+        end
+      end
+    end
+  end
+
+  describe '#destroy' do
+    let(:user) do
+      { id: 1, name: 'John', email: 'john@gotmail.com' }
+    end
+
+    before do
+      Test::App.resolve('repositories.user').push(::User.new(*user.values))
+    end
+
+    context 'with invalid user_id' do
+      it 'returns a 404 with an empty hash representation' do
+        delete '/defaults/users/2', {}
+
+        expect(last_response.status).to eq(404)
+        expect(last_response.body).to eq({}.to_json)
+      end
+    end
+
+    context 'with valid user_id' do
+      it 'returns a 200 with an empty hash representation' do
+        delete '/defaults/users/1', {}
+
+        expect(last_response.status).to eq(200)
+        expect(last_response.body).to eq({}.to_json)
+      end
+    end
+  end
+end

--- a/spec/integration/roda/plugins/flow/proc_controller_flow__with_defaults_spec.rb
+++ b/spec/integration/roda/plugins/flow/proc_controller_flow__with_defaults_spec.rb
@@ -1,0 +1,194 @@
+require 'spec_helper'
+require 'support/test_repository'
+require 'support/register_lambdas'
+require 'support/test_user'
+
+RSpec.describe 'flow plugin with defaults' do
+  before do
+    module Test
+      User = Struct.new(:id, :name, :email)
+
+      class App < Roda
+        plugin :all_verbs
+        plugin :json
+        plugin :container
+        plugin :flow
+
+        route do |r|
+          r.on 'defaults' do
+            r.on 'users' do
+              r.resolve 'repositories.user' do |user_repository|
+                flow_defaults(inject: [response, user_repository], call_with: [r.params]) do
+                  r.is do
+                    r.get to: 'controllers.index_users',
+                      inject: [user_repository],
+                      call_with: false
+                    r.post to: 'controllers.create_user'
+                  end
+
+                  r.on :user_id do |user_id|
+                    flow_defaults(call_with: [user_id]) do
+                      r.get to: 'controllers.show_user'
+
+                      r.put to: 'controllers.update_user',
+                        call_with: [user_id, r.params]
+
+                      r.delete to: 'controllers.destroy_user'
+                    end
+                  end
+                end
+              end
+            end
+          end
+        end
+
+        register('repositories.user', ::TestRepository.new)
+        namespace 'controllers' do
+          RegisterLambdas.run(self)
+        end
+      end
+    end
+  end
+
+  describe '#index' do
+    let(:users) do
+      [
+        { id: 1, name: 'John', email: 'john@gotmail.com' },
+        { id: 2, name: 'Jill', email: 'jill@gotmail.com' }
+      ]
+    end
+
+    before do
+      repo = Test::App.resolve('repositories.user')
+      users.each do |user_attributes|
+        repo.push(Test::User.new(*user_attributes.values))
+      end
+    end
+
+    it 'returns a 200 with users array representation' do
+      get '/defaults/users', {}
+
+      expect(last_response.status).to eq(200)
+      expect(last_response.body).to eq(users.to_json)
+    end
+  end
+
+  describe '#show' do
+    let(:user) do
+      { id: 1, name: 'John', email: 'john@gotmail.com' }
+    end
+
+    before do
+      Test::App.resolve('repositories.user').push(Test::User.new(*user.values))
+    end
+
+    context 'with invalid user_id' do
+      it 'returns a 404 with an empty hash representation' do
+        get '/defaults/users/2', {}
+
+        expect(last_response.status).to eq(404)
+        expect(last_response.body).to eq({}.to_json)
+      end
+    end
+
+    context 'with valid user_id' do
+      it 'returns a 200 with the user representation' do
+        get '/defaults/users/1', {}
+
+        expect(last_response.status).to eq(200)
+        expect(last_response.body).to eq(user.to_json)
+      end
+    end
+  end
+
+  describe '#create' do
+    context 'with invalid params' do
+      it 'returns a 422 with an invalid user representation' do
+        post '/defaults/users', name: '', email: 'john@gotmail.com'
+
+        expect(last_response.status).to eq(422)
+        expect(last_response.body).to eq({
+          id: nil,
+          name: '',
+          email: 'john@gotmail.com'
+        }.to_json)
+      end
+    end
+
+    context 'with valid params' do
+      it 'returns a 201 with the user representation' do
+        post '/defaults/users', name: 'John', email: 'john@gotmail.com'
+
+        expect(last_response.status).to eq(201)
+        expect(last_response.body).to eq({ id: 1, name: 'John', email: 'john@gotmail.com' }.to_json)
+      end
+    end
+  end
+
+  describe '#update' do
+    let(:user) do
+      { id: 1, name: 'John', email: 'john@gotmail.com' }
+    end
+
+    before do
+      Test::App.resolve('repositories.user').push(Test::User.new(*user.values))
+    end
+
+    context 'with invalid user_id' do
+      it 'returns a 404 with an empty hash representation' do
+        put '/defaults/users/2', name: 'John Smith'
+
+        expect(last_response.status).to eq(404)
+        expect(last_response.body).to eq({}.to_json)
+      end
+    end
+
+    context 'with valid user_id' do
+      context 'with invalid params' do
+        it 'returns a 422 with the invalid user representation' do
+          put '/defaults/users/1', name: ''
+
+          expect(last_response.status).to eq(422)
+          expect(last_response.body).to eq(user.update(name: '').to_json)
+        end
+      end
+
+      context 'with valid params' do
+        it 'returns a 200 with the user representation' do
+          put '/defaults/users/1', name: 'John Smith'
+
+          expect(last_response.status).to eq(200)
+          expect(last_response.body).to eq(user.update(name: 'John Smith').to_json)
+        end
+      end
+    end
+  end
+
+  describe '#destroy' do
+    let(:user) do
+      { id: 1, name: 'John', email: 'john@gotmail.com' }
+    end
+
+    before do
+      Test::App.resolve('repositories.user').push(Test::User.new(*user.values))
+    end
+
+    context 'with invalid user_id' do
+      it 'returns a 404 with an empty hash representation' do
+        delete '/defaults/users/2', {}
+
+        expect(last_response.status).to eq(404)
+        expect(last_response.body).to eq({}.to_json)
+      end
+    end
+
+    context 'with valid user_id' do
+      it 'returns a 200 with an empty hash representation' do
+        delete '/defaults/users/1', {}
+
+        expect(last_response.status).to eq(200)
+        expect(last_response.body).to eq({}.to_json)
+      end
+    end
+  end
+end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -1,3 +1,4 @@
+$LOAD_PATH.unshift(File.dirname(__FILE__))
 require 'roda'
 require 'rack/test'
 

--- a/spec/support/register_lambdas.rb
+++ b/spec/support/register_lambdas.rb
@@ -1,0 +1,67 @@
+class RegisterLambdas
+
+  def self.run(app)
+    app.register('index_users') do |user_repository|
+      -> { user_repository.all.map(&:to_h) }
+    end
+
+    app.register('show_user') do |response, user_repository|
+      lambda do |user_id|
+        if (user = user_repository[user_id.to_i])
+          user.to_h
+        else
+          response.status = 404
+          {}
+        end
+      end
+    end
+
+    app.register('create_user') do |response, user_repository|
+      lambda do |params|
+        user = ::User.new(nil, *params.values_at('name', 'email'))
+
+        if !params.values.map(&:to_s).any?(&:empty?)
+          response.status = 201
+          user_repository.push(
+            user
+          ).to_h
+        else
+          response.status = 422
+          user.to_h
+        end
+      end
+    end
+
+    app.register('update_user') do |response, user_repository|
+      lambda do |user_id, params|
+        if (user = user_repository[user_id.to_i])
+          params = params.each_with_object(user.to_h) { |(k, v), h| h[k.to_sym] = v }
+
+          if params.values.map(&:to_s).any?(&:empty?)
+            response.status = 422
+            params
+          else
+            user_repository.update(
+              ::User.new(*params.values)
+            ).to_h
+          end
+        else
+          response.status = 404
+          {}
+        end
+      end
+    end
+
+    app.register('destroy_user') do |response, user_repository|
+      lambda do |user_id|
+        if (user = user_repository[user_id.to_i])
+          user_repository.delete(user)
+          {}
+        else
+          response.status = 404
+          {}
+        end
+      end
+    end
+  end
+end

--- a/spec/support/test_repository.rb
+++ b/spec/support/test_repository.rb
@@ -1,0 +1,28 @@
+class TestRepository
+  attr_accessor :data
+
+  def initialize(data = {})
+    self.data = data
+  end
+
+  def all
+    data.values
+  end
+
+  def [](id)
+    data[id]
+  end
+
+  def push(obj)
+    obj.id = data.values.length.next
+    data[obj.id] = obj
+  end
+
+  def update(obj)
+    data[obj.id] = obj
+  end
+
+  def delete(obj)
+    data.delete(obj.id)
+  end
+end

--- a/spec/support/test_user.rb
+++ b/spec/support/test_user.rb
@@ -1,0 +1,1 @@
+User = Struct.new(:id, :name, :email)

--- a/spec/support/users_controller.rb
+++ b/spec/support/users_controller.rb
@@ -1,0 +1,63 @@
+class UsersController
+  attr_reader :response, :user_repository
+
+  def initialize(response, user_repository)
+    @response = response
+    @user_repository = user_repository
+  end
+
+  def index
+    user_repository.all.map(&:to_h)
+  end
+
+  def show(user_id)
+    if (user = user_repository[user_id.to_i])
+      user.to_h
+    else
+      response.status = 404
+      {}
+    end
+  end
+
+  def create(params)
+    user = User.new(nil, *params.values_at('name', 'email'))
+
+    if !params.values.map(&:to_s).any?(&:empty?)
+      response.status = 201
+      user_repository.push(
+        user
+      ).to_h
+    else
+      response.status = 422
+      user.to_h
+    end
+  end
+
+  def update(user_id, params)
+    if (user = user_repository[user_id.to_i])
+      params = params.each_with_object(user.to_h) { |(k, v), h| h[k.to_sym] = v }
+
+      if params.values.map(&:to_s).any?(&:empty?)
+        response.status = 422
+        params
+      else
+        user_repository.update(
+          User.new(*params.values)
+        ).to_h
+      end
+    else
+      response.status = 404
+      {}
+    end
+  end
+
+  def destroy(user_id)
+    if (user = user_repository[user_id.to_i])
+      user_repository.delete(user)
+      {}
+    else
+      response.status = 404
+      {}
+    end
+  end
+end


### PR DESCRIPTION
Should be pretty self-explanatory, but here's some code from the tests: 

```
        route do |r|
          r.on 'defaults' do
            r.on 'users' do
              r.resolve('repositories.user') do |user_repo|
                flow_defaults(inject: [r.response, user_repo], call_with: [r.params]) do
                  r.is do
                    r.get to: 'controllers.users#index',
                      call_with: false 

                    r.post to: 'controllers.users#create'
                  end

                  r.on :user_id do |user_id|
                    flow_defaults(call_with: [user_id]) do
                      r.get to: 'controllers.users#show'

                      r.put to: 'controllers.users#update',
                        call_with: [user_id, r.params]

                      r.delete to: 'controllers.users#destroy'
                    end
                  end
                end
              end
            end
          end
        end
```
