### PR TITLE
Directly yield resolved container objects

### DIFF
--- a/lib/roda/plugins/flow.rb
+++ b/lib/roda/plugins/flow.rb
@@ -2,17 +2,11 @@ class Roda
   module RodaPlugins
     module Flow
       module RequestMethods
-        def resolve(*args, &block)
-          on(resolve: args, &block)
+        def resolve(*keys)
+          yield *keys.map { |key| roda_class.resolve(key) }
         end
 
         private
-
-        def match_resolve(resolve)
-          Array(resolve).flatten.each do |key|
-            @captures << roda_class.resolve(key)
-          end
-        end
 
         def match_to(to)
           container_key, @block_method = to.to_s.split('#')


### PR DESCRIPTION
Doing this instead of using Roda’s route matching system means that an r.resolve block doesn’t affect the Roda app’s current match block, which means that request methods like `r.pass` continue to be useful inside a resolve block.

Resolves #3