### PR TITLE
[WIP] Call #to_s to play correctly with Dry::View::Rendered

### DIFF
--- a/lib/roda/plugins/flow.rb
+++ b/lib/roda/plugins/flow.rb
@@ -49,7 +49,7 @@ class Roda
           @captures.clear
 
           if match_all(args)
-            block_result(get_block(&block).call(*captures))
+            block_result(get_block(&block).call(*captures).to_s)
             throw :halt, response.finish
           else
             @remaining_path = path


### PR DESCRIPTION
`dry-view` controller `#call` method no longer return a string, but a `Dry::View::Rendered` instance, which `#to_s` method needs to be called to get the actual output. Otherwise, roda will fail with:

```
Roda::RodaError:
        unsupported block result: #<Dry::View::Rendered output="...
```

I confess I'm submitting this PR without a full understanding of the issue, but I think it is a good idea to prepare it right now for three reasons:

- Make the problem visible.
- Help others which can encounter the same issue.
- Get the full understanding from here.

I guess `roda-flow` was designed independently from `dry-view`, but debugging it I have reached here as the source of the error, and I think right now this project and `dry-web-roda` (where `dry-view` roda plugin lives) are collaborating mutually. If I have to submit the issue in `dry-web-roda` instead, please, tell me.

References dry-rb/dry-view#72